### PR TITLE
Add blog and new site sections

### DIFF
--- a/components/Companies.tsx
+++ b/components/Companies.tsx
@@ -5,7 +5,7 @@ export default function Companies() {
         <div className="flex flex-wrap justify-center text-center">
           <div className="w-full lg:w-6/12 px-4">
             <h1 className="text-gray-900 text-4xl font-bold mb-4">
-              Work at these companies
+              Our members have gotten offers from these companies
             </h1>
 
             <p className="text-gray-700 text-lg font-light">

--- a/components/DiscordInvite.tsx
+++ b/components/DiscordInvite.tsx
@@ -1,0 +1,16 @@
+export default function DiscordInvite() {
+  return (
+    <div className="bg-indigo-600 py-16" id="discord">
+      <div className="max-w-4xl mx-auto text-center px-4 text-white">
+        <h2 className="text-3xl font-bold mb-4">Join our Discord</h2>
+        <p className="mb-6">Connect with the community and stay up to date.</p>
+        <a
+          href="https://discord.com/invite/"
+          className="inline-block bg-white text-indigo-600 font-semibold px-6 py-3 rounded-md"
+        >
+          Join Now
+        </a>
+      </div>
+    </div>
+  );
+}

--- a/components/Hero.tsx
+++ b/components/Hero.tsx
@@ -6,7 +6,10 @@ const navigation = [
   { name: "Home", href: "#home" },
   { name: "About", href: "#about" },
   { name: "Team", href: "#team" },
+  { name: "Events", href: "#events" },
+  { name: "Blog", href: "/blog" },
   { name: "Contact", href: "#contact" },
+  { name: "Discord", href: "#discord" },
 ];
 
 export default function Hero() {
@@ -14,19 +17,15 @@ export default function Hero() {
 
   return (
     <div className="bg-white" id="home">
-      <header className="absolute inset-x-0 top-0 z-50">
+      <header className="sticky top-0 bg-white/70 backdrop-blur z-50">
         <nav
           className="flex items-center justify-between p-6 lg:px-8"
           aria-label="Global"
         >
-          <div className="flex lg:flex-1">
-            <a href="#" className="-m-1.5 p-1.5">
-              <span className="sr-only">Dalhousie CSL</span>
-              {/* <img
-                className="h-8 w-auto"
-                src="https://tailwindui.com/img/logos/mark.svg?color=indigo&shade=600"
-                alt=""
-              /> */}
+          <div className="flex lg:flex-1 items-center">
+            <a href="#" className="flex items-center space-x-2">
+              <img src="/assets/leetcode.webp" alt="Logo" className="h-8 w-8" />
+              <span className="font-semibold text-gray-900">Dal CSL</span>
             </a>
           </div>
           <div className="flex lg:hidden">

--- a/components/ICPC.tsx
+++ b/components/ICPC.tsx
@@ -1,0 +1,12 @@
+export default function ICPC() {
+  return (
+    <div className="bg-gray-50 py-16" id="icpc">
+      <div className="max-w-4xl mx-auto text-center px-4">
+        <h2 className="text-3xl font-bold mb-4">ICPC Training</h2>
+        <p className="text-gray-700">
+          Join our weekly sessions to prepare for the ICPC and other programming competitions.
+        </p>
+      </div>
+    </div>
+  );
+}

--- a/components/LatestUpdates.tsx
+++ b/components/LatestUpdates.tsx
@@ -1,0 +1,14 @@
+export default function LatestUpdates() {
+  return (
+    <div className="bg-gray-50 py-16" id="updates">
+      <div className="max-w-4xl mx-auto text-center px-4">
+        <h2 className="text-3xl font-bold mb-4">Latest Updates</h2>
+        <p className="mb-6 text-gray-700">Follow us on LinkedIn and Instagram for the latest news.</p>
+        <div className="flex justify-center space-x-6">
+          <a href="https://www.linkedin.com/company/dal-csl/" className="text-indigo-600 font-semibold">LinkedIn</a>
+          <a href="https://www.instagram.com/dalcsl/" className="text-indigo-600 font-semibold">Instagram</a>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/components/MockInterviews.tsx
+++ b/components/MockInterviews.tsx
@@ -1,0 +1,20 @@
+export default function MockInterviews() {
+  return (
+    <div className="bg-white py-16" id="mock-interviews">
+      <div className="max-w-4xl mx-auto text-center px-4">
+        <h2 className="text-3xl font-bold mb-4">Mock Interviews</h2>
+        <p className="mb-8 text-gray-700">
+          We conduct mock technical, behavioural and system design interviews. Book a slot with us!
+        </p>
+        <div className="w-full h-96">
+          <iframe
+            src="https://calendly.com"
+            className="w-full h-full border-0"
+            title="Calendly"
+            loading="lazy"
+          />
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/components/Team.tsx
+++ b/components/Team.tsx
@@ -72,38 +72,21 @@ export default function Team() {
 
         <div className="flex flex-wrap justify-center">
           {people.map((person) => (
-            <div className="w-full md:w-6/12 lg:w-4/12 mb-6 px-8 sm:px-6 lg:px-4 py-8">
-              <div className="flex flex-col items-center">
+            <div
+              key={person.name}
+              className="w-full md:w-6/12 lg:w-4/12 mb-6 px-8 sm:px-6 lg:px-4 py-8"
+            >
+              <div className="group relative flex flex-col items-center">
                 <img
-                  className="rounded-full w-1/2 drop-shadow-md hover:drop-shadow-xl transition-all duration-200 delay-100"
+                  className="rounded-md w-full h-72 object-cover"
                   src={person.imageUrl}
-                  style={{
-                    height: "225px",
-                    width: "225px",
-                    objectFit: "cover",
-                  }}
+                  alt={person.name}
                 />
-
-                <div className="text-center mt-6">
-                  <h1 className="text-gray-900 text-lg font-bold mb-1">
-                    {person.name}
-                  </h1>
-
-                  <h4 className="text-gray-700 text-md font-light mb-2">
-                    {person.role}
-                  </h4>
-
-                  {/* <div className="flex items-center justify-center duration-300">
-                    <Link href="">
-                      <AiOutlineLinkedin className="h-6 w-6 m-1" />
-                    </Link>
-                    <Link href="">
-                      <AiOutlineInstagram className="h-6 w-6 m-1" />
-                    </Link>
-                    <Link href="">
-                      <AiFillGithub className="h-6 w-6 m-1" />
-                    </Link>
-                  </div> */}
+                <div
+                  className="absolute inset-0 flex flex-col items-center justify-center bg-black/70 opacity-0 group-hover:opacity-100 transition-opacity"
+                >
+                  <h3 className="text-white text-lg font-bold">{person.name}</h3>
+                  <p className="text-white text-sm">{person.role}</p>
                 </div>
               </div>
             </div>

--- a/components/Testimonials.tsx
+++ b/components/Testimonials.tsx
@@ -1,0 +1,41 @@
+import { useEffect, useState } from 'react';
+
+const testimonials = [
+  {
+    quote: 'This society helped me land my dream job!',
+    name: 'Alice',
+  },
+  {
+    quote: 'Great community and amazing events.',
+    name: 'Bob',
+  },
+  {
+    quote: 'The mock interviews were super helpful.',
+    name: 'Charlie',
+  },
+];
+
+export default function Testimonials() {
+  const [index, setIndex] = useState(0);
+
+  useEffect(() => {
+    const id = setInterval(() => {
+      setIndex((i) => (i + 1) % testimonials.length);
+    }, 4000);
+    return () => clearInterval(id);
+  }, []);
+
+  const t = testimonials[index];
+
+  return (
+    <div className="bg-white py-16" id="testimonials">
+      <div className="max-w-xl mx-auto text-center px-4">
+        <h2 className="text-3xl font-bold mb-8">Testimonials</h2>
+        <div className="relative">
+          <p className="text-xl italic">"{t.quote}"</p>
+          <p className="mt-4 font-semibold">- {t.name}</p>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/components/UpcomingEvents.tsx
+++ b/components/UpcomingEvents.tsx
@@ -1,0 +1,13 @@
+export default function UpcomingEvents() {
+  return (
+    <div className="bg-white py-16" id="events">
+      <div className="max-w-4xl mx-auto px-4">
+        <h2 className="text-3xl font-bold mb-8 text-center">Upcoming Events</h2>
+        <ul className="space-y-4 text-gray-700">
+          <li>Stay tuned for our next workshop!</li>
+          <li>ICPC practice session next week.</li>
+        </ul>
+      </div>
+    </div>
+  );
+}

--- a/lib/sanity.ts
+++ b/lib/sanity.ts
@@ -1,0 +1,13 @@
+import { createClient } from '@sanity/client';
+
+export const sanityClient = createClient({
+  projectId: process.env.SANITY_PROJECT_ID || '',
+  dataset: process.env.SANITY_DATASET || 'production',
+  useCdn: true,
+  apiVersion: '2023-01-01',
+});
+
+export async function getPosts() {
+  const query = `*[_type == "post"]{_id, title, description}`;
+  return await sanityClient.fetch(query);
+}

--- a/package.json
+++ b/package.json
@@ -14,7 +14,8 @@
     "next": "latest",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
-    "react-icons": "^4.8.0"
+    "react-icons": "^4.8.0",
+    "@sanity/client": "^6.17.2"
   },
   "devDependencies": {
     "@tailwindcss/forms": "^0.5.3",

--- a/pages/api/posts/index.ts
+++ b/pages/api/posts/index.ts
@@ -1,0 +1,14 @@
+import type { NextApiRequest, NextApiResponse } from 'next';
+import { getPosts } from '../../../lib/sanity';
+
+export default async function handler(
+  _req: NextApiRequest,
+  res: NextApiResponse
+) {
+  try {
+    const posts = await getPosts();
+    res.status(200).json(posts);
+  } catch (e: any) {
+    res.status(500).json({ message: e.message });
+  }
+}

--- a/pages/blog.tsx
+++ b/pages/blog.tsx
@@ -1,0 +1,41 @@
+import { GetStaticProps } from 'next';
+import { getPosts } from '../lib/sanity';
+
+interface Post {
+  _id: string;
+  title: string;
+  description: string;
+}
+
+interface BlogProps {
+  posts: Post[];
+}
+
+export default function Blog({ posts }: BlogProps) {
+  return (
+    <div className="max-w-3xl mx-auto py-12 px-4">
+      <h1 className="text-4xl font-bold mb-8">Blog</h1>
+      {posts && posts.length ? (
+        <ul className="space-y-6">
+          {posts.map((post) => (
+            <li key={post._id} className="border-b pb-4">
+              <h2 className="text-2xl font-semibold">{post.title}</h2>
+              <p className="text-gray-700">{post.description}</p>
+            </li>
+          ))}
+        </ul>
+      ) : (
+        <p>No posts found.</p>
+      )}
+    </div>
+  );
+}
+
+export const getStaticProps: GetStaticProps = async () => {
+  try {
+    const posts = await getPosts();
+    return { props: { posts } };
+  } catch (e) {
+    return { props: { posts: [] } };
+  }
+};

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -11,6 +11,12 @@ import Services from "../components/Services";
 import Stats from "../components/Stats";
 import Team from "../components/Team";
 import UserForm from "../components/UserForm";
+import MockInterviews from "../components/MockInterviews";
+import ICPC from "../components/ICPC";
+import UpcomingEvents from "../components/UpcomingEvents";
+import LatestUpdates from "../components/LatestUpdates";
+import DiscordInvite from "../components/DiscordInvite";
+import Testimonials from "../components/Testimonials";
 
 const IndexPage = () => {
   return (
@@ -18,8 +24,14 @@ const IndexPage = () => {
       <Hero />
       <Companies />
       <Content />
+      <MockInterviews />
+      <ICPC />
       <CTA />
+      <UpcomingEvents />
+      <Testimonials />
       <Team />
+      <LatestUpdates />
+      <DiscordInvite />
       {/* <Stats /> */}
       <JoinUs />
       {/* <Features />  */}


### PR DESCRIPTION
## Summary
- integrate simple Sanity client
- create Blog page and API route for posts
- add mock interview, ICPC training, upcoming events, latest updates, discord invite and testimonials sections
- update team section with hover cards
- update companies heading
- tweak sticky navbar with logo and new links

## Testing
- `npm run type-check` *(fails: Cannot find module 'react', etc.)*

------
https://chatgpt.com/codex/tasks/task_e_68596a0447e4832391ba2432ffd04cea